### PR TITLE
Use larger read/write/handler timeouts to allow large uploads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A web UI for uploading files into the data discovery project.
 | TOPIC_NAME           | dp-csv-splitter  | The name of the topic to send file uploaded events to
 | AWS_REGION           | eu-west-1        | The AWS region the S3 bucket is hosted in
 | S3_BUCKET            | file-uploaded    | The name of the S3 bucket to store files.
+| UPLOAD_TIMEOUT       | 1m               | The time before an upload times out. Use 'm' for minutes, 's' for seconds etc.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A web UI for uploading files into the data discovery project.
 | TOPIC_NAME           | dp-csv-splitter  | The name of the topic to send file uploaded events to
 | AWS_REGION           | eu-west-1        | The AWS region the S3 bucket is hosted in
 | S3_BUCKET            | file-uploaded    | The name of the S3 bucket to store files.
-| UPLOAD_TIMEOUT       | 1m               | The time before an upload times out. Use 'm' for minutes, 's' for seconds etc.
+| UPLOAD_TIMEOUT       | 1m               | The time before an upload times out. Use 'm' for minutes, 's' for seconds etc. Maximum of 1h.
 
 ### Contributing
 

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ import (
 	"html/template"
 	"net/http"
 	"os"
-	"time"
 )
 
 func main() {
@@ -50,7 +49,7 @@ func main() {
 
 	router := pat.New()
 	alice := alice.New(
-		timeout.Handler(10*time.Second),
+		timeout.Handler(config.UploadTimeout),
 		log.Handler,
 		requestID.Handler(16),
 	).Then(router)
@@ -64,8 +63,8 @@ func main() {
 	server := &http.Server{
 		Addr:         bindAddr,
 		Handler:      alice,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  config.UploadTimeout,
+		WriteTimeout: config.UploadTimeout,
 	}
 
 	if err := server.ListenAndServe(); err != nil {


### PR DESCRIPTION
### What

Increase the default read/write and handler timeouts to allow large uploads to complete.
NB: due to nature of timeouts in Go (see https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) we need to increase all three timeouts as reading the uploaded request body is covered by all 3. I've also made the timeout configurable via a single env variable.

### How to review

Build and test with a large file (100+MB) with different timeout values.

### Who can review

Anyone but me.