### PR TITLE
#919 Fix upload for large files

### DIFF
--- a/config/uploader.go
+++ b/config/uploader.go
@@ -14,6 +14,7 @@ const awsRegionKey = "AWS_REGION"
 const topicNameKey = "TOPIC_NAME"
 const timeoutKey = "UPLOAD_TIMEOUT"
 const s3URLKey = "S3_URL"
+const uploadTempDirKey = "UPLOAD_TEMP_DIR"
 
 const maxUploadTimeout = 1 * time.Hour
 
@@ -37,6 +38,9 @@ var UploadTimeout = 10 * time.Minute
 
 // Default S3 URL value.
 var S3URL, _ = url.Parse("s3://dp-csv-splitter-develop/" + os.Getenv("USER"))
+
+// UploadTempDir is the directory to store uploaded files in temporarily before uploading to S3.
+var UploadTempDir = os.TempDir()
 
 func init() {
 	if bindAddrEnv := os.Getenv(bindAddrKey); len(bindAddrEnv) > 0 {
@@ -75,16 +79,21 @@ func init() {
 			os.Exit(1)
 		}
 	}
+
+	if uploadDir := os.Getenv(uploadTempDirKey); len(uploadDir) > 0 {
+		UploadTempDir = uploadDir
+	}
 }
 
 func Load() {
 	// Will call init().
 	log.Debug("dp-dd-file-uploader Configuration", log.Data{
-		bindAddrKey:  BindAddr,
-		kafkaAddrKey: KafkaAddr,
-		topicNameKey: TopicName,
-		awsRegionKey: AWSRegion,
-		timeoutKey:   UploadTimeout,
-		s3URLKey:     S3URL,
+		bindAddrKey:      BindAddr,
+		kafkaAddrKey:     KafkaAddr,
+		topicNameKey:     TopicName,
+		awsRegionKey:     AWSRegion,
+		timeoutKey:       UploadTimeout,
+		s3URLKey:         S3URL,
+		uploadTempDirKey: UploadTempDir,
 	})
 }

--- a/handler/upload.go
+++ b/handler/upload.go
@@ -14,6 +14,10 @@ import (
 	"github.com/ONSdigital/dp-dd-file-uploader/render"
 	"github.com/ONSdigital/go-ns/handlers/response"
 	"github.com/ONSdigital/go-ns/log"
+	"os"
+	"io/ioutil"
+	"github.com/ONSdigital/dp-dd-file-uploader/config"
+	"mime/multipart"
 )
 
 var FileStore file.Store
@@ -40,62 +44,108 @@ func Upload(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	file, header, err := req.FormFile("file")
+	multipartReader, err := req.MultipartReader()
 	if err != nil {
-		log.ErrorR(req, err, log.Data{"message": FailedToReadRequest})
-		err = response.WriteJSON(w, Response{Message: FailedToReadRequest}, http.StatusBadRequest)
-		if err != nil {
-			log.ErrorR(req, err, log.Data{"message": "Failed to write JSON response"})
-			w.WriteHeader(http.StatusBadRequest)
-		}
-		return
-	}
-	defer func() {
-		err = file.Close()
-		if err != nil {
-			log.ErrorR(req, err, nil)
-		}
-	}()
-
-	log.DebugR(req, "Attempting to read file from request", log.Data{"filename": header.Filename})
-
-	reader := CreateValidatingReader(file, log.Context(req))
-
-	log.DebugR(req, "Streaming file to s3", log.Data{"filename": header.Filename})
-
-	err = FileStore.SaveFile(reader, header.Filename)
-
-	if err != nil {
-		log.Error(err, log.Data{"message": FailedToSaveFile})
-		err = response.WriteJSON(w, Response{Message: fmt.Sprintf("%s %v", FailedToSaveFile, err)}, http.StatusInternalServerError)
-		if err != nil {
-			log.Error(err, log.Data{"message": "Failed to write JSON response"})
-			w.WriteHeader(http.StatusInternalServerError)
-		}
+		handleFileReadFailure(w, req, err, nil)
 		return
 	}
 
-	event := event.FileUploaded{
-		Time:  time.Now().UTC().Unix(),
-		S3URL: S3Config.GetS3FileURL(header.Filename),
+	var part *multipart.Part
+	for {
+		part, err = multipartReader.NextPart()
+		if err != nil {
+			handleFileReadFailure(w, req, err, nil)
+			return
+		}
+		if part != nil && part.FormName() == "file" {
+			break
+		}
 	}
 
-	err = EventProducer.FileUploaded(event)
+	// NB: we will get an io.EOF error above if the part was not found, so part will not be nil here
+	defer part.Close()
+
+	tempFile, err := ioutil.TempFile(config.UploadTempDir, "file-upload-")
 	if err != nil {
-		log.Error(err, log.Data{"message": FailedToSendEvent})
-		response.WriteJSON(w, Response{Message: FailedToSendEvent}, http.StatusInternalServerError)
-		if err != nil {
-			log.Error(err, log.Data{"message": "Failed to write JSON response"})
-			w.WriteHeader(http.StatusInternalServerError)
-		}
+		handleFileReadFailure(w, req, err, tempFile)
 		return
 	}
+	log.DebugR(req, "Writing file upload to temporary file", log.Data{
+		"filename": tempFile.Name(),
+	});
+
+	bytesWritten, err := io.Copy(tempFile, CreateValidatingReader(part, log.Context(req)))
+	if err != nil {
+		handleFileReadFailure(w, req, err, tempFile)
+		return
+	}
+	log.DebugR(req, "Successfully wrote file to temporary storage", log.Data{
+		"size": bytesWritten,
+	})
+
+	// Rewind file to start ready to read and stream to S3
+	_, err = tempFile.Seek(0, io.SeekStart)
+	if err != nil {
+		handleFileReadFailure(w, req, err, tempFile)
+		return
+	}
+
+	// Continue upload to S3 in a separate goroutine
+	go uploadFileToS3(tempFile, part.FileName(), log.Context(req))
 
 	err = render.Home(w)
 	if err != nil {
 		log.Error(err, log.Data{"message": "Failed to render home page"})
 	}
+}
 
+func uploadFileToS3(file *os.File, filename string, context string) {
+	defer (func() {
+		err := file.Close()
+		if err != nil {
+			log.ErrorC(context, err, log.Data{"filename": file.Name()})
+		}
+
+		err = os.Remove(file.Name())
+		if err != nil {
+			log.ErrorC(context, err, log.Data{"filename": file.Name()})
+		}
+	})()
+
+	log.DebugC(context, "Streaming file to s3", log.Data{"filename": filename})
+
+	err := FileStore.SaveFile(file, filename)
+	if err != nil {
+		log.ErrorC(context, err, log.Data{"message": FailedToSaveFile})
+		return
+	}
+
+	uploadedEvent := event.FileUploaded{
+		Time:  time.Now().UTC().Unix(),
+		S3URL: S3Config.GetS3FileURL(filename),
+	}
+
+	err = EventProducer.FileUploaded(uploadedEvent)
+	if err != nil {
+		log.ErrorC(context, err, log.Data{"message": FailedToSendEvent})
+		return
+	}
+}
+
+func handleFileReadFailure(w http.ResponseWriter, req *http.Request, err error, tempFile *os.File) {
+	log.ErrorR(req, err, log.Data{"message": FailedToReadRequest})
+	err = response.WriteJSON(w, Response{Message: FailedToReadRequest}, http.StatusBadRequest)
+	if err != nil {
+		log.ErrorR(req, err, log.Data{"message": "Failed to write JSON response"})
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	if tempFile != nil {
+		err = os.Remove(tempFile.Name())
+		if err != nil {
+			log.ErrorR(req, err, log.Data{"message": "Unable to remove temporary file", "file": tempFile.Name()})
+		}
+	}
 }
 
 // CreateValidatingReader creates a reader that will return an error if the stream being read does not represent a valid csv file.
@@ -111,7 +161,7 @@ func CreateValidatingReader(sourceReader io.Reader, context string) io.Reader {
 			row, err := csvReader.Read()
 			if err != nil {
 				pipeWriter.CloseWithError(err)
-				log.DebugC(context, "Finished sending file to s3", log.Data{"rowCount": rowCount, "err": err})
+				log.DebugC(context, "Finished saving file to disk", log.Data{"rowCount": rowCount, "err": err})
 				return
 			}
 			if len(row)%3 != 0 {
@@ -119,8 +169,8 @@ func CreateValidatingReader(sourceReader io.Reader, context string) io.Reader {
 				pipeWriter.CloseWithError(errors.New(message))
 				return
 			}
-			if rowCount%10000 == 0 {
-				log.DebugC(context, "Sending file to s3", log.Data{"rowCount": rowCount})
+			if rowCount%50000 == 0 {
+				log.DebugC(context, "Saving file to local disk", log.Data{"rowCount": rowCount})
 			}
 		}
 	}()

--- a/handler/upload_test.go
+++ b/handler/upload_test.go
@@ -75,7 +75,7 @@ func TestUploadHandler(t *testing.T) {
 		So(response.Message, ShouldEqual, handlers.FailedToReadRequest)
 	})
 
-	Convey("Handler returns 200 status code response when request body is a valid file", t, func() {
+	Convey("Handler returns 202 Accepted status code response when request body is a valid file", t, func() {
 		fileStore := filetest.NewDummyFileStore()
 		handlers.FileStore = fileStore
 		eventProducer := eventtest.NewDummyEventProducer()
@@ -93,61 +93,10 @@ func TestUploadHandler(t *testing.T) {
 		json.Unmarshal([]byte(recorder.Body.String()), response)
 
 		fmt.Println(recorder.Body)
-		So(recorder.Code, ShouldEqual, 200)
+		So(recorder.Code, ShouldEqual, 202)
 		So(fileStore.Invocations, ShouldEqual, 1)
 	})
 
-	Convey("Handler returns 500 status code response when file save fails.", t, func() {
-		fileStore := filetest.NewDummyFileStore()
-		handlers.FileStore = fileStore
-		eventProducer := eventtest.NewDummyEventProducer()
-		handlers.EventProducer = eventProducer
-
-		recorder := httptest.NewRecorder()
-
-		// set a known filename allowing the file save error to be returned.
-		requestBody := strings.Replace(exampleMultipartBody, "AF001EW.csv", "fileSaveError.csv", 1)
-		requestBodyReader := bytes.NewReader([]byte(requestBody))
-		request, err := http.NewRequest("POST", "/", requestBodyReader)
-		request.Header.Add("Content-Type", "multipart/form-data; boundary=----WebKitFormBoundaryezYpRsrGowIiw0K4")
-		So(err, ShouldBeNil)
-
-		handlers.Upload(recorder, request)
-
-		var response = &handlers.Response{}
-		json.Unmarshal([]byte(recorder.Body.String()), response)
-
-		fmt.Println(recorder.Body)
-		So(recorder.Code, ShouldEqual, 500)
-		So(fileStore.Invocations, ShouldEqual, 1)
-		So(response.Message, ShouldContainSubstring, handlers.FailedToSaveFile)
-	})
-
-	Convey("Handler returns 500 status code response when event send fails.", t, func() {
-		fileStore := filetest.NewDummyFileStore()
-		handlers.FileStore = fileStore
-		eventProducer := eventtest.NewDummyEventProducer()
-		handlers.EventProducer = eventProducer
-
-		recorder := httptest.NewRecorder()
-
-		// set a known filename allowing the event error to be returned.
-		requestBody := strings.Replace(exampleMultipartBody, "AF001EW.csv", "EventError.csv", 1)
-		requestBodyReader := bytes.NewReader([]byte(requestBody))
-		request, err := http.NewRequest("POST", "/", requestBodyReader)
-		request.Header.Add("Content-Type", "multipart/form-data; boundary=----WebKitFormBoundaryezYpRsrGowIiw0K4")
-		So(err, ShouldBeNil)
-
-		handlers.Upload(recorder, request)
-
-		var response = &handlers.Response{}
-		json.Unmarshal([]byte(recorder.Body.String()), response)
-
-		fmt.Println(recorder.Body)
-		So(recorder.Code, ShouldEqual, 500)
-		So(fileStore.Invocations, ShouldEqual, 1)
-		So(response.Message, ShouldEqual, handlers.FailedToSendEvent)
-	})
 }
 
 func TestValidatingReader(t *testing.T) {

--- a/render/home.go
+++ b/render/home.go
@@ -13,5 +13,5 @@ type renderer interface {
 var Renderer renderer
 
 func Home(w io.Writer) error {
-	return Renderer.HTML(w, http.StatusOK, "index", "")
+	return Renderer.HTML(w, http.StatusAccepted, "index", "")
 }


### PR DESCRIPTION
### What

Fixes an issue with some browsers (Chrome, Firefox) restarting the file upload if the server takes too long to respond. The real solution in Beta will be to use chunked uploads direct from the browser, as described in a previous spike, but that is quite tricky to setup securely. This PR mitigates the issue for alpha by a number of techniques:

 - Moves the costly upload to S3 into a separate background goroutine so that we can send a response to the browser as soon as the file is saved locally
 - Adds support for uploading as zip files - currently this will just decompress them when uploading to S3 so that downstream components still get the raw files. This hugely decreases the time a user has to wait for the upload to complete.

### How to review

`make debug` and try uploading a large file.

### Who can review

Anyone but me.